### PR TITLE
Sticky header attempt #2

### DIFF
--- a/web/src/components/layout.tsx
+++ b/web/src/components/layout.tsx
@@ -19,7 +19,7 @@ export interface LayoutProps {
 }
 
 const Layout = (props: LayoutProps) => {
-  const { children, siteTitle, contactInfo = {}, isDark } = props;
+  const { children, contactInfo = {}, isDark } = props;
 
   const { instagram, email } = contactInfo;
 

--- a/web/src/components/layout.tsx
+++ b/web/src/components/layout.tsx
@@ -3,6 +3,7 @@ import Container from './container';
 import Header from './header';
 
 import styled from 'styled-components';
+import GlobalFonts from '../styles/globalFonts';
 import GlobalStyle from '../styles/globalStyles';
 import { theme } from '../styles/theme';
 import { DeviceWidth } from '../styles/mediaQueries';
@@ -24,6 +25,7 @@ const Layout = (props: LayoutProps) => {
 
   return (
     <>
+      <GlobalFonts />
       <GlobalStyle />
 
       <PageWrapper>

--- a/web/src/containers/layout.tsx
+++ b/web/src/containers/layout.tsx
@@ -1,7 +1,6 @@
 import { graphql, StaticQuery } from 'gatsby';
 import React, { useState } from 'react';
 import Layout from '../components/layout';
-import '../styles/global-fonts.css';
 
 const query = graphql`
   query SiteTitleQuery {

--- a/web/src/styles/globalFonts.ts
+++ b/web/src/styles/globalFonts.ts
@@ -1,0 +1,80 @@
+import { createGlobalStyle, css } from 'styled-components';
+import { DeviceWidth } from './mediaQueries';
+
+import MaisonNeue2 from '../assets/MaisonNeueExtendedWEB-Medium.woff2';
+import MaisonNeue from '../assets/MaisonNeueExtendedWEB-Medium.woff';
+
+import Chalet from '../assets/Chalet-LondonNineteenSixty.otf';
+
+const globalFonts = css`
+  :root {
+    @font-face {
+      font-family: 'Maison Neue';
+      src: url(${MaisonNeue2}) format('woff2'), url(${MaisonNeue}) format('woff');
+    }
+
+    @font-face {
+      font-family: 'Chalet';
+      src: url(${Chalet}) format('opentype');
+    }
+
+    --font-family-maison-neue: 'Maison Neue', -apple-system, BlinkMacSystemFont, sans-serif;
+    --font-family-chalet: 'Chalet', -apple-system, BlinkMacSystemFont, sans-serif;
+
+    --unit: 16;
+
+    --font-base-size: 1em; /* 16px */
+    --font-base-line-height: calc(24 / var(--unit)); /* 24px */
+
+    --font-interface18-size: calc(18 / var(--unit) * 1rem); /* 18px */
+    --font-interface18-line-height: calc(18 / 18);
+
+    --font-interface20-size: calc(20 / var(--unit) * 1rem); /* 20px */
+    --font-interface20-line-height: calc(20 / 20);
+
+    --font-body18-size: calc(18 / var(--unit) * 1rem); /* 18px */
+    --font-body18-line-height: calc(18 / 18);
+
+    --font-body20-size: calc(20 / var(--unit) * 1rem); /* 20px */
+    --font-body20-line-height: calc(24 / 20);
+
+    --font-body24-size: calc(24 / var(--unit) * 1rem); /* 24px */
+    --font-body24-line-height: calc(32 / 24);
+
+    --font-title24-size: calc(24 / var(--unit) * 1rem); /* 24px */
+    --font-title24-line-height: calc(32 / 24);
+
+    --font-title48-size: calc(48 / var(--unit) * 1rem); /* 48px */
+    --font-title48-line-height: calc(64 / 48);
+
+    @media (${DeviceWidth.mediaMaxSmall}) {
+      --font-base-size: 1em; /* 16px */
+      --font-base-line-height: calc(24 / var(--unit)); /* 24px */
+
+      --font-interface18-size: calc(14 / var(--unit) * 1rem); /* 18px */
+      --font-interface18-line-height: calc(14 / 14);
+
+      --font-interface20-size: calc(13 / var(--unit) * 1rem); /* 20px */
+      --font-interface20-line-height: calc(13 / 13);
+
+      --font-body18-size: calc(10 / var(--unit) * 1rem); /* 18px */
+      --font-body18-line-height: calc(18 / 18);
+
+      --font-body20-size: calc(14 / var(--unit) * 1rem); /* 20px */
+      --font-body20-line-height: calc(24 / 20);
+
+      --font-body24-size: calc(12 / var(--unit) * 1rem); /* 24px */
+      --font-body24-line-height: calc(32 / 24);
+
+      --font-title24-size: calc(18 / var(--unit) * 1rem); /* 24px */
+      --font-title24-line-height: calc(32 / 24);
+
+      --font-title48-size: calc(18 / var(--unit) * 1rem); /* 48px */
+      --font-title48-line-height: calc(64 / 48);
+    }
+  }
+`;
+
+const GlobalFonts = createGlobalStyle`${globalFonts}`;
+
+export default GlobalFonts;


### PR DESCRIPTION
see #6 for previous change notes 

Reverted back to using styled-components globalFonts.ts file instead of importing a css file.
For some reason importing the css file anywhere in the app causes the production build to break and basically the deployed site doesn't have any javascript. I think the issue might be that the pages are not "hydrating", but I don't fully understand how gatsby works behind the scenes yet. 

Can't find anything on the internet about this problem. This is very frustrating.